### PR TITLE
fix(projects): ignore linked archived projects & improve header layout

### DIFF
--- a/addon/components/model-form/header.hbs
+++ b/addon/components/model-form/header.hbs
@@ -1,4 +1,4 @@
-<div class="uk-flex uk-flex-between uk-flex-top uk-margin-top">
+<div class="uk-flex uk-flex-between uk-flex-top uk-margin-top uk-child-width-1-2">
   <ModelForm::Header::Title
     @model={{@model}}
     @modelId={{@modelId}}

--- a/addon/components/model-form/header/actions.hbs
+++ b/addon/components/model-form/header/actions.hbs
@@ -4,18 +4,19 @@
     @import={{@import}}
     @modelName={{@modelName}}
   />
-  <div class="uk-flex-inline uk-flex-right uk-flex-middle">
+  <div class="uk-flex uk-flex-bottom uk-flex-column-reverse">
     {{#if (and @modelHasImport @import)}}
+    <div class="uk-flex uk-flex-wrap uk-flex-right">
       {{#if (and @import.originalData.length (is-unset @import.index))}}
         <LinkTo
-          class="uk-button uk-button-default uk-margin-small-right uk-flex-none"
+          class="uk-button uk-button-default uk-flex-none"
           @query={{hash index=null}}
         >
           {{t "ember-gwr.components.importModal.selectImportData"}}
         </LinkTo>
       {{else}}
         <button
-          class="uk-button uk-button-default uk-flex-none
+          class="uk-button uk-button-default uk-flex-none uk-margin-small-left
             {{if (is-unset @import.index) 'uk-margin-small-right'}}"
           type="button"
           {{on "click" @importAllData}}
@@ -24,7 +25,7 @@
         </button>
         {{#if (and @import @import.originalData.length)}}
           <button
-            class="uk-button uk-button-default uk-flex-none uk-padding-small uk-padding-remove-vertical uk-margin-small-right"
+            class="uk-button uk-button-default uk-flex-none uk-padding-small uk-padding-remove-vertical"
             type="button"
             disabled={{@disabled}}
           >
@@ -51,11 +52,13 @@
       {{/if}}
       <LinkTo
         @query={{hash import=false index=undefined}}
-        class="uk-button uk-button-default uk-flex-none uk-margin-small-right"
+        class="uk-button uk-button-default uk-flex-none uk-margin-small-left"
       >
         {{t "ember-gwr.components.modelForm.cancelImport"}}
       </LinkTo>
+    </div>
     {{/if}}
+    <div class="uk-margin-small-bottom uk-margin-small-left">
     {{#let @submit as |Submit|}}
       <Submit />
     {{/let}}
@@ -110,6 +113,7 @@
         </ul>
       </div>
     {{/if}}
+    </div>
   </div>
   <div class="uk-margin-small-top uk-flex uk-flex-right">
     {{#let @submitErrors as |SubmitErrors|}}

--- a/addon/controllers/project.js
+++ b/addon/controllers/project.js
@@ -19,7 +19,7 @@ export default class ProjectController extends Controller {
 
   get displayLandingPage() {
     return (
-      !this.projects.value.length &&
+      !this.projects.value?.length &&
       this.router.externalRouter.currentRoute.localName !== "new" &&
       this.router.externalRouter.currentRoute.localName !== "errors"
     );

--- a/addon/services/construction-project.js
+++ b/addon/services/construction-project.js
@@ -25,7 +25,17 @@ export default class ConstructionProjectService extends GwrService {
       `/constructionprojects/${EPROID}`
     );
     const xml = await response.text();
-    return this.createAndCache(xml);
+    const project = this.createAndCache(xml);
+
+    // Archived GWR projects aren't removed from the stored instance links, but
+    // can no longer be fetched through the API. Those projects are therefore
+    // ignored, might be better to properly remove the associated links in the
+    // future.
+    if (!project.EPROID) {
+      return null;
+    }
+
+    return project;
   }
 
   async update(project) {
@@ -157,7 +167,9 @@ export default class ConstructionProjectService extends GwrService {
     const projects = yield Promise.all(
       links.map(({ eproid }) => this.getFromCacheOrApi(eproid))
     );
-    return projects;
+
+    // Remove no longer available projects
+    return projects.filter(Boolean);
   }
 
   async removeProjectLink(projectId) {

--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -80,7 +80,7 @@
         @addLink={{this.addWorkLink}}
       >
         <:list as |model|>
-          <td class="uk-table-expand">
+          <td class="uk-table-expand uk-width-expand">
             <div class="uk-flex-inline uk-flex-middle">
               {{#if model.isNew}}
                 <div class="uk-form-label uk-margin-small-right uk-margin">

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -72,7 +72,7 @@ ember-gwr:
       Für Tiefbauprojekte sind keine Gebäude zugelassen.
       Die Art der Arbeiten werden direkt auf dem Projekt erfasst.
     superstructureInfo: |-
-      Für Hochbauprojekte werden die Art der Arbeiten ausschliesslich gebäudebezogen gemeldet.
+      Für Hochbauprojekte werden die Art der Arbeiten gebäudebezogen gemeldet.
     specialstructureInfo: |-
       Für Sonderbauprojekte sind ausschliesslich Gebäude der Gebäudekategorie Sonderbau zugelassen.
     buildingDisabledForNewProject: Während des Erstellens eines Projektes können noch keine Gebäude erfasst werden.
@@ -333,7 +333,7 @@ ember-gwr:
       linkSuccess: Strasse erfolgreich verknüpft.
       linkError: Bei der Verknüpfung der Strasse ist ein Fehler aufgetreten.
       streetHint: Um einen Eingang zu erfassen müssen Sie eine Strasse verknüpfen.
-      searchHint: 'Ein Stern (*) kann in der Suche als Platzhalter verwendet werden, um nach Teilen eines Strassennamen zu suchen.'
+      searchHint: 'Ein Stern (*) kann in der Suche als Platzhalter verwendet werden, um nach Teilen eines Strassennamens zu suchen.'
       searchHintExamples: Beispiele
       searchHintExamples1: 'Unter* : Unterfeldweg, Unterschlossweg'
       searchHintExamples2: '*weg : Waldweg, Unterschlossweg'


### PR DESCRIPTION
Ignore archived or deactivated construction projects, that are still referenced through an instance link, but can no longer be retrieved through the API. In addition, improve the header layout such that element wrapping is applied properly when little space is available.