### PR TITLE
fix(buildings): never disable linked building tab

### DIFF
--- a/addon/components/project-nav.hbs
+++ b/addon/components/project-nav.hbs
@@ -43,7 +43,6 @@
     </Tab.item>
     <Tab.item
       @href={{build-url "project.linked-buildings" (array @activeProjectId)}}
-      @disabled={{this.buildingTabInfoText}}
     >
       {{t "ember-gwr.models.building" count=1}}
     </Tab.item>


### PR DESCRIPTION
Remove disabling of linked buildings tab to allow users to unlink buildings when switching from superstructure projects to infrastructure projects.