### PR TITLE
fix: initial setup of canton to local storage

### DIFF
--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,10 +7,12 @@ export default class ApplicationController extends Controller {
   constructor(...args) {
     super(...args);
     let canton = localStorage.getItem("canton");
-    if (!canton) {
+    if (!canton || canton === "null") {
       //eslint-disable-next-line no-alert
       canton = prompt("canton (BE|SZ)");
-      localStorage.setItem("canton", canton);
+      if (canton) {
+        localStorage.setItem("canton", canton);
+      }
     }
     this.canton = canton;
   }


### PR DESCRIPTION
In case one accidentally closes the initial prompt asking for the canton, there is no way back (besides clearing localStorage) to receive that prompt again. This took me some time to realize while onboarding. Just to prevent future devs to experience the same I would suggest this small fix.

## Explanation
After the first prompt the localStorage key `canton` will resolve to `null`. This get's somehow transformed into a string `"null"` which will not fall into the `if (!canton)` trap and prevent further prompts for the current canton. This halts the application as it runs into an error.

![image](https://github.com/inosca/ember-ebau-gwr/assets/10029904/17bd7bb7-aec6-4ae5-bd2b-31cd144593f4)
 