### PR TITLE
fix(project): revert handling of missing current route information

### DIFF
--- a/addon/controllers/project.js
+++ b/addon/controllers/project.js
@@ -10,7 +10,7 @@ export default class ProjectController extends Controller {
   @service constructionProject;
 
   get activeProjectId() {
-    return Number(this.router.externalRouter.currentRoute?.params.project_id);
+    return Number(this.router.externalRouter.currentRoute.params.project_id);
   }
 
   get isLoading() {
@@ -20,8 +20,8 @@ export default class ProjectController extends Controller {
   get displayLandingPage() {
     return (
       !this.projects.value?.length &&
-      this.router.externalRouter.currentRoute?.localName !== "new" &&
-      this.router.externalRouter.currentRoute?.localName !== "errors"
+      this.router.externalRouter.currentRoute.localName !== "new" &&
+      this.router.externalRouter.currentRoute.localName !== "errors"
     );
   }
 


### PR DESCRIPTION
Instance-links don't correctly redirect to the relevant project. Handling null accesses currently leads to display issues in the navigation and need to be properly addressed and fixed.