### PR TITLE
feat: improve streeet search component

### DIFF
--- a/addon/components/model-form.hbs
+++ b/addon/components/model-form.hbs
@@ -85,7 +85,7 @@
           model=f.model
           importedData=this.importData
           translationBase=@translationBase
-          input=f.input
+          inputComponent=f.input
           registerDiff=this.registerDiff
           resolveDiff=this.resolveDiff
           disabled=@disabled

--- a/addon/components/model-form/field.hbs
+++ b/addon/components/model-form/field.hbs
@@ -4,7 +4,7 @@
 >
   {{#let
     (component
-      @input
+      @inputComponent
       label=(unless
         @noLabel (t (or @label (concat @translationBase "." @attr)))
       )
@@ -45,6 +45,7 @@
         max=@max
       )
       errorComponent=(component "validated-form-error")
+      model=@model
     )
     as |InputComponent|
   }}

--- a/addon/components/search-street.hbs
+++ b/addon/components/search-street.hbs
@@ -3,33 +3,39 @@
       "ember-gwr.buildingEntrance.fields.street.description.descriptionLong"
     }}{{if @required " *"}}
   </label>
-  <PowerSelect
-    @disabled={{@disabled}}
-    @renderInPlace={{true}}
-    @tabIndex={{"0"}}
-    @triggerClass="uk-select"
-    @searchEnabled={{true}}
-    @search={{perform this.search}}
-    @selected={{@street}}
-    @onChange={{@onChange}}
-    @onFocus={{this.handleFocus}}
-    @searchMessage={{t "ember-gwr.components.linkStreet.search"}}
-    @noMatchesMessage={{t "ember-gwr.components.search.noResults"}}
-    @loadingMessage={{t "ember-gwr.components.search.loading"}}
-    id={{this.guid}}
-    class="uk-overflow-hidden"
-    ...attributes
-    as |streetList|
-  >
-    {{streetList.description.descriptionLong}}{{#if
-      streetList.description.descriptionLong
-    }}
-      <small
-        data-test-street-esid
-        class="uk-text-muted uk-text-right uk-text-italic uk-margin-small-left"
-      >{{t "ember-gwr.street.ESID"}}: {{streetList.ESID}}</small>
-    {{/if}}
-  </PowerSelect>
+  <div class="uk-form-controls">
+    <PowerSelect
+      @disabled={{@disabled}}
+      @renderInPlace={{true}}
+      @tabIndex={{"0"}}
+      @triggerClass="uk-select"
+      @searchEnabled={{true}}
+      @search={{perform this.search}}
+      @selected={{@value}}
+      @onChange={{queue (fn (mut this.dirty) true) @on-update}}
+      @onFocus={{this.handleFocus}}
+      @searchMessage={{t "ember-gwr.components.linkStreet.search"}}
+      @noMatchesMessage={{t "ember-gwr.components.search.noResults"}}
+      @loadingMessage={{t "ember-gwr.components.search.loading"}}
+      id={{this.inputId}}
+      class={{class-list
+        "uk-overflow-hidden"
+        (if this.isValid "uk-form-success")
+        (if this.isInvalid "uk-form-danger")
+      }}
+      ...attributes
+      as |streetList|
+    >
+      {{streetList.description.descriptionLong}}{{#if
+        streetList.description.descriptionLong
+      }}
+        <small
+          data-test-street-esid
+          class="uk-text-muted uk-text-right uk-text-italic uk-margin-small-left"
+        >{{t "ember-gwr.locality.name.nameLong"}}: {{streetList.locality.name.nameLong}}, {{t "ember-gwr.street.ESID"}}: {{streetList.ESID}}</small>
+      {{/if}}
+    </PowerSelect>
+  </div>
   {{#if @disabled}}
     <small data-test-hint class="uk-text-muted">{{t
         "ember-gwr.components.streetSearch.requiredInputs"

--- a/addon/components/search-street.hbs
+++ b/addon/components/search-street.hbs
@@ -30,10 +30,15 @@
         streetList.description.descriptionLong
       }}
         <small
-          data-test-street-esid
+          data-test-search-street-locality-name
           class="uk-text-muted uk-text-right uk-text-italic uk-margin-small-left"
         >{{t "ember-gwr.locality.name.nameLong"}}:
           {{streetList.locality.name.nameLong}},
+        </small>
+        <small
+          data-test-search-street-esid
+          class="uk-text-muted uk-text-right uk-text-italic uk-margin-small-left"
+        >
           {{t "ember-gwr.street.ESID"}}:
           {{streetList.ESID}}</small>
       {{/if}}

--- a/addon/components/search-street.hbs
+++ b/addon/components/search-street.hbs
@@ -1,5 +1,5 @@
 <div class="uk-margin">
-  <label class="uk-form-label" for={{this.guid}}>{{t
+  <label class="uk-form-label" for={{this.inputId}}>{{t
       "ember-gwr.buildingEntrance.fields.street.description.descriptionLong"
     }}{{if @required " *"}}
   </label>
@@ -32,7 +32,10 @@
         <small
           data-test-street-esid
           class="uk-text-muted uk-text-right uk-text-italic uk-margin-small-left"
-        >{{t "ember-gwr.locality.name.nameLong"}}: {{streetList.locality.name.nameLong}}, {{t "ember-gwr.street.ESID"}}: {{streetList.ESID}}</small>
+        >{{t "ember-gwr.locality.name.nameLong"}}:
+          {{streetList.locality.name.nameLong}},
+          {{t "ember-gwr.street.ESID"}}:
+          {{streetList.ESID}}</small>
       {{/if}}
     </PowerSelect>
   </div>
@@ -40,5 +43,7 @@
     <small data-test-hint class="uk-text-muted">{{t
         "ember-gwr.components.streetSearch.requiredInputs"
       }}</small>
+    <br />
   {{/if}}
+  {{component @errorComponent errors=this.errors}}
 </div>

--- a/addon/components/search-street.js
+++ b/addon/components/search-street.js
@@ -1,30 +1,23 @@
 import { action } from "@ember/object";
-import { guidFor } from "@ember/object/internals";
 import { inject as service } from "@ember/service";
 import { isBlank } from "@ember/utils";
-import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { task, timeout } from "ember-concurrency";
+import ValidatedInput from "ember-validated-form/components/validated-input";
 
-export default class SearchStreetComponent extends Component {
+export default class SearchStreetComponent extends ValidatedInput {
   @service("street") streetAPI;
   @service notification;
   @service intl;
 
   @tracked searchTerm = "";
 
-  constructor(...args) {
-    super(...args);
-
-    this.guid = guidFor(this);
-  }
-
   get swissZipCode() {
-    return this.args.locality.swissZipCode;
+    return this.args.options.locality.swissZipCode;
   }
 
   get swissZipCodeAddOn() {
-    return this.args.locality.swissZipCodeAddOn;
+    return this.args.options.locality.swissZipCodeAddOn;
   }
 
   get query() {

--- a/addon/components/search-street.js
+++ b/addon/components/search-street.js
@@ -19,10 +19,6 @@ export default class SearchStreetComponent extends Component {
     this.guid = guidFor(this);
   }
 
-  get localityName() {
-    return this.args.locality.name.nameLong;
-  }
-
   get swissZipCode() {
     return this.args.locality.swissZipCode;
   }
@@ -40,9 +36,6 @@ export default class SearchStreetComponent extends Component {
       locality: {
         swissZipCode: this.swissZipCode,
         swissZipCodeAddOn: this.swissZipCodeAddOn,
-        name: {
-          nameLong: this.localityName,
-        },
       },
       language: this.streetAPI.language,
     };

--- a/addon/controllers/building/edit/entrance/edit/index.js
+++ b/addon/controllers/building/edit/entrance/edit/index.js
@@ -48,6 +48,17 @@ export default class BuildingEditEntranceEditIndexController extends ImportContr
     this.fetchBuildingEntrance.perform();
   }
 
+  @action
+  syncLocalityWithSelectedStreet(changeset, streetList) {
+    changeset.set("locality.street", streetList);
+    changeset.set("locality.name.nameLong", streetList.locality.name.nameLong);
+    changeset.set("locality.swissZipCode", streetList.locality.swissZipCode);
+    changeset.set(
+      "locality.swissZipCodeAddOn",
+      streetList.locality.swissZipCodeAddOn,
+    );
+  }
+
   @dropTask
   *saveBuildingEntrance() {
     try {

--- a/addon/controllers/building/edit/form.js
+++ b/addon/controllers/building/edit/form.js
@@ -100,6 +100,13 @@ export default class BuildingFormController extends ImportController {
     this.fetchBuildingWork.perform();
   }
 
+  @action
+  syncLocalityWithStreet(changeset, streetList) {
+    changeset.set("building.buildingEntrance.locality.name.nameLong", streetList.locality.name.nameLong)
+    changeset.set("building.buildingEntrance.locality.swissZipCode", streetList.locality.swissZipCode)
+    changeset.set("building.buildingEntrance.locality.swissZipCodeAddOn", streetList.locality.swissZipCodeAddOn)
+  }
+
   @dropTask
   *saveBuildingWork() {
     try {

--- a/addon/controllers/building/edit/form.js
+++ b/addon/controllers/building/edit/form.js
@@ -102,9 +102,18 @@ export default class BuildingFormController extends ImportController {
 
   @action
   syncLocalityWithStreet(changeset, streetList) {
-    changeset.set("building.buildingEntrance.locality.name.nameLong", streetList.locality.name.nameLong)
-    changeset.set("building.buildingEntrance.locality.swissZipCode", streetList.locality.swissZipCode)
-    changeset.set("building.buildingEntrance.locality.swissZipCodeAddOn", streetList.locality.swissZipCodeAddOn)
+    changeset.set(
+      "building.buildingEntrance.locality.name.nameLong",
+      streetList.locality.name.nameLong,
+    );
+    changeset.set(
+      "building.buildingEntrance.locality.swissZipCode",
+      streetList.locality.swissZipCode,
+    );
+    changeset.set(
+      "building.buildingEntrance.locality.swissZipCodeAddOn",
+      streetList.locality.swissZipCodeAddOn,
+    );
   }
 
   @dropTask

--- a/addon/templates/building/edit/entrance/edit/index.hbs
+++ b/addon/templates/building/edit/entrance/edit/index.hbs
@@ -27,8 +27,8 @@
       {{/unless}}
       <Field
         @attr="locality.name.nameLong"
-        @required={{true}}
         @disabled={{not this.buildingEntrance.isNew}}
+        @required={{true}}
       />
       <Field
         @attr="locality.swissZipCode"
@@ -37,17 +37,22 @@
         @required={{true}}
       />
       {{#if this.buildingEntrance.isNew}}
-        <SearchStreet
-          @locality={{changeset-get changeset "locality"}}
-          @street={{changeset-get changeset "street"}}
+        <Field
+          @attr="street"
+          @label="ember-gwr.buildingEntrance.fields.street.description.descriptionLong"
+          @inputComponent="search-street"
+          @options={{hash
+            locality=(changeset-get
+              changeset "locality"
+            )
+          }}
+          @on-update={{fn this.syncLocalityWithSelectedStreet changeset}}
           @disabled={{not
-            (and
-              (changeset-get changeset "locality.swissZipCode")
-              (changeset-get changeset "locality.name.nameLong")
+            (changeset-get
+              changeset "locality.swissZipCode"
             )
           }}
           @required={{true}}
-          @onChange={{fn (mut this.buildingEntrance.street)}}
         />
       {{else}}
         <Field

--- a/addon/templates/building/edit/form.hbs
+++ b/addon/templates/building/edit/form.hbs
@@ -150,11 +150,6 @@
           {{t "ember-gwr.building.buildingEntrance.info"}}
         </small>
         <Field
-          @attr="building.buildingEntrance.locality.name.nameLong"
-          @required={{true}}
-          @label="ember-gwr.buildingEntrance.fields.locality.name.nameLong"
-        />
-        <Field
           @attr="building.buildingEntrance.locality.swissZipCode"
           @type="number"
           @label="ember-gwr.buildingEntrance.fields.locality.swissZipCode"

--- a/addon/templates/building/edit/form.hbs
+++ b/addon/templates/building/edit/form.hbs
@@ -164,6 +164,7 @@
               changeset "building.buildingEntrance.locality"
             )
           }}
+          @on-update={{fn this.syncLocalityWithStreet changeset}}
           @disabled={{not
             (changeset-get
               changeset "building.buildingEntrance.locality.swissZipCode"

--- a/addon/templates/building/edit/form.hbs
+++ b/addon/templates/building/edit/form.hbs
@@ -155,17 +155,21 @@
           @label="ember-gwr.buildingEntrance.fields.locality.swissZipCode"
           @required={{true}}
         />
-        <SearchStreet
-          @locality={{changeset-get changeset "building.buildingEntrance.locality"}}
-          @street={{changeset-get changeset "building.buildingEntrance.street"}}
+        <Field
+          @attr="building.buildingEntrance.locality.street"
+          @label="ember-gwr.buildingEntrance.fields.street.description.descriptionLong"
+          @inputComponent="search-street"
+          @options={{hash
+            locality=(changeset-get
+              changeset "building.buildingEntrance.locality"
+            )
+          }}
           @disabled={{not
-            (and
-              (changeset-get changeset "building.buildingEntrance.locality.swissZipCode")
-              (changeset-get changeset "building.buildingEntrance.locality.name.nameLong")
+            (changeset-get
+              changeset "building.buildingEntrance.locality.swissZipCode"
             )
           }}
           @required={{true}}
-          @onChange={{fn (changeset-set changeset "building.buildingEntrance.street")}}
         />
         <Field
           @attr="building.buildingEntrance.buildingEntranceNo"

--- a/addon/validations/building-entrance.js
+++ b/addon/validations/building-entrance.js
@@ -11,8 +11,6 @@ export default {
       validatePresence(true),
       validateNumber({ integer: true, gte: 1000, lte: 9699 }),
     ],
-    name: {
-      nameLong: [validatePresence(true), validateLength({ min: 2, max: 40 })],
-    },
+    street: [validatePresence(true)],
   },
 };

--- a/addon/xml/templates/street.js
+++ b/addon/xml/templates/street.js
@@ -1,6 +1,6 @@
 // prettier-ignore
 export const getStreet =
-`{{#>base}}
+  `{{#>base}}
   <ns2:getStreet>
     {{#if model.description.descriptionLong}}
       <ns2:description>
@@ -8,6 +8,8 @@ export const getStreet =
         <ns2:descriptionLong>{{model.description.descriptionLong}}</ns2:descriptionLong>
       </ns2:description>
     {{/if}}
-    {{> Locality model=model.locality}}
+    {{#if model.locality.nameLong}}
+      {{> Locality model=model.locality}}
+    {{/if}}
   </ns2:getStreet>
 {{/base}}`;

--- a/app/styles/_validated-form.scss
+++ b/app/styles/_validated-form.scss
@@ -2,4 +2,14 @@
   .uk-form-label {
     @extend .uk-text-bold;
   }
+
+  .ember-power-select-trigger {
+    &.uk-form-success {
+      border-color: $alert-success-color;
+    }
+
+    &.uk-form-danger {
+      border-color: $alert-danger-color;
+    }
+  }
 }

--- a/app/styles/ember-ebau-gwr.scss
+++ b/app/styles/ember-ebau-gwr.scss
@@ -11,7 +11,8 @@ $ember-power-select-trigger-icon-color: transparent;
     @extend .uk-invisible;
   }
 
-  .ember-power-select-option:hover > small {
+  .ember-power-select-option:hover > small,
+  .ember-power-select-option[aria-current="true"] > small {
     mix-blend-mode: multiply;
   }
 }

--- a/tests/integration/components/search-street-test.js
+++ b/tests/integration/components/search-street-test.js
@@ -8,10 +8,10 @@ import {
 } from "ember-power-select/test-support/helpers";
 import { module, test } from "qunit";
 
-module("Integration | Component | search-street", function (hooks) {
+module("Integration | Component | search-street", function(hooks) {
   setupRenderingTest(hooks);
 
-  test("it renders", async function (assert) {
+  test("it renders", async function(assert) {
     this.set("street");
     this.set("options", {
       locality: {
@@ -81,9 +81,12 @@ module("Integration | Component | search-street", function (hooks) {
       .dom(".ember-power-select-selected-item")
       .containsText("Eisenburgstrasse");
     assert
-      .dom(".ember-power-select-selected-item [data-test-street-esid]")
-      .hasText(
-        "t:ember-gwr.locality.name.nameLong:(): , t:ember-gwr.street.ESID:(): 1234",
-      );
+      .dom(
+        ".ember-power-select-selected-item [data-test-search-street-locality-name]",
+      )
+      .hasText("t:ember-gwr.locality.name.nameLong:(): ,");
+    assert
+      .dom(".ember-power-select-selected-item [data-test-search-street-esid]")
+      .hasText("t:ember-gwr.street.ESID:(): 1234");
   });
 });

--- a/tests/integration/components/search-street-test.js
+++ b/tests/integration/components/search-street-test.js
@@ -8,10 +8,10 @@ import {
 } from "ember-power-select/test-support/helpers";
 import { module, test } from "qunit";
 
-module("Integration | Component | search-street", function(hooks) {
+module("Integration | Component | search-street", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it renders", async function(assert) {
+  test("it renders", async function (assert) {
     this.set("street");
     this.set("options", {
       locality: {

--- a/tests/integration/components/search-street-test.js
+++ b/tests/integration/components/search-street-test.js
@@ -8,10 +8,10 @@ import {
 } from "ember-power-select/test-support/helpers";
 import { module, test } from "qunit";
 
-module("Integration | Component | search-street", function(hooks) {
+module("Integration | Component | search-street", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it renders", async function(assert) {
+  test("it renders", async function (assert) {
     this.set("street");
     this.set("options", {
       locality: {
@@ -82,6 +82,8 @@ module("Integration | Component | search-street", function(hooks) {
       .containsText("Eisenburgstrasse");
     assert
       .dom(".ember-power-select-selected-item [data-test-street-esid]")
-      .hasText("t:ember-gwr.locality.name.nameLong:(): , t:ember-gwr.street.ESID:(): 1234");
+      .hasText(
+        "t:ember-gwr.locality.name.nameLong:(): , t:ember-gwr.street.ESID:(): 1234",
+      );
   });
 });

--- a/tests/integration/components/search-street-test.js
+++ b/tests/integration/components/search-street-test.js
@@ -8,16 +8,15 @@ import {
 } from "ember-power-select/test-support/helpers";
 import { module, test } from "qunit";
 
-module("Integration | Component | search-street", function (hooks) {
+module("Integration | Component | search-street", function(hooks) {
   setupRenderingTest(hooks);
 
-  test("it renders", async function (assert) {
+  test("it renders", async function(assert) {
     this.set("street");
-    this.set("locality", {
-      swissZipCode: "8862",
-      swissZipCodeAddOn: "",
-      name: {
-        nameLong: "Schübelbach",
+    this.set("options", {
+      locality: {
+        swissZipCode: "8862",
+        swissZipCodeAddOn: "",
       },
     });
     this.set("disabled", true);
@@ -37,9 +36,6 @@ module("Integration | Component | search-street", function (hooks) {
         locality: {
           swissZipCode: "8862",
           swissZipCodeAddOn: "",
-          name: {
-            nameLong: "Schübelbach",
-          },
         },
         language: undefined,
       });
@@ -55,11 +51,11 @@ module("Integration | Component | search-street", function (hooks) {
     };
 
     await render(hbs`<SearchStreet
-      @locality={{this.locality}}
-      @street={{this.street}}
+      @options={{this.options}}
+      @value={{this.street}}
       @disabled={{this.disabled}}
       @required={{true}}
-      @onChange={{this.update}}
+      @on-update={{this.update}}
       class="test-search"
     />`);
 
@@ -86,6 +82,6 @@ module("Integration | Component | search-street", function (hooks) {
       .containsText("Eisenburgstrasse");
     assert
       .dom(".ember-power-select-selected-item [data-test-street-esid]")
-      .hasText("t:ember-gwr.street.ESID:(): 1234");
+      .hasText("t:ember-gwr.locality.name.nameLong:(): , t:ember-gwr.street.ESID:(): 1234");
   });
 });

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -346,4 +346,4 @@ ember-gwr:
       empty: Keine offenen Pendenzen
 
     streetSearch:
-      requiredInputs: Bitte geben Sie zuerst Ortsname und PLZ an.
+      requiredInputs: Bitte geben Sie zuerst Ihre PLZ an.

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -346,4 +346,4 @@ ember-gwr:
       empty: Pas de dossiers/ cas en suspens
 
     streetSearch:
-      requiredInputs: Veuillez d'abord entrer le nom de votre ville et votre code postal.
+      requiredInputs: Veuillez d'abord entrer votre code postal.


### PR DESCRIPTION
First part of implementing #738 

**Building creation**

- [x] Remove locality name as an input field, getStreet only uses the PLZ
- [x] Display the locality name in the street search options
- [x] Use the locality returned in the getStreet response for the addBuildingToConstructionProject request

**Street validation**

- [x] Make the street input required through a validation check

## Preview

### Disabled + invalid state (same as disabled)
![image](https://github.com/inosca/ember-ebau-gwr/assets/10029904/362d2677-56f2-47b2-b4ed-0d1927aae8db)

### Enabled + invalid state
![image](https://github.com/inosca/ember-ebau-gwr/assets/10029904/06c0ab1f-0ee2-4516-a17e-4ad1fa87231f)

### Enabled + valid state
![image](https://github.com/inosca/ember-ebau-gwr/assets/10029904/16f7ef93-5707-4b54-8ad0-f476525eb65e)
