### PR TITLE
feat: improve streeet search api

### DIFF
--- a/addon/models/options.js
+++ b/addon/models/options.js
@@ -270,7 +270,7 @@ export const countryOptions = [
   "cy",
 ];
 
-export const languageOptions = { de: 9901, fr: 9903, it: 9904 };
+export const languageOptions = { de: 9901, rm: 9902, fr: 9903, it: 9904 };
 
 export const periodOfConstructionOptions = [
   8011, 8012, 8013, 8014, 8015, 8016, 8017, 8018, 8019, 8020, 8021, 8022, 8023,

--- a/addon/services/languages.js
+++ b/addon/services/languages.js
@@ -1,0 +1,51 @@
+import Service, { inject as service } from "@ember/service";
+import { languageOptions } from "ember-ebau-gwr/models/options";
+
+export default class LanguagesService extends Service {
+  @service config;
+
+  languages = {
+    AG: ["de"],
+    AR: ["de"],
+    AI: ["de"],
+    BL: ["de"],
+    BS: ["de"],
+    BE: ["de", "fr"],
+    FR: ["de", "fr"],
+    GE: ["de", "fr"],
+    GL: ["de"],
+    GR: ["de", "rm", "it"],
+    JU: ["fr"],
+    LU: ["de"],
+    NE: ["fr"],
+    NW: ["de"],
+    OW: ["de"],
+    SH: ["de"],
+    SZ: ["de"],
+    SO: ["de"],
+    SG: ["de"],
+    TI: ["it"],
+    TG: ["de"],
+    UR: ["de"],
+    VD: ["fr"],
+    VS: ["de", "fr"],
+    ZG: ["de"],
+    ZH: ["de"],
+  };
+
+  get availableLanguages() {
+    return this.config.cantonAbbreviation
+      ? this.languages[this.config.cantonAbbreviation]
+      : ["de", "rm", "fr", "it"];
+  }
+
+  codeToLanguage(code) {
+    return Object.entries(languageOptions).find(
+      ([, value]) => value === code,
+    )[0];
+  }
+
+  languageToCode(languageAbbreviation) {
+    return languageOptions[languageAbbreviation];
+  }
+}

--- a/tests/unit/services/languages-test.js
+++ b/tests/unit/services/languages-test.js
@@ -1,0 +1,37 @@
+import { setupTest } from "dummy/tests/helpers";
+import { module, test } from "qunit";
+
+module("Unit | Service | languages", function (hooks) {
+  setupTest(hooks);
+
+  test("available languages for a given canton", function (assert) {
+    const configService = this.owner.lookup("service:config");
+    const languagesService = this.owner.lookup("service:languages");
+
+    configService.cantonAbbreviation = "GR";
+
+    assert.deepEqual(languagesService.availableLanguages, ["de", "rm", "it"]);
+
+    configService.cantonAbbreviation = "BE";
+
+    assert.deepEqual(languagesService.availableLanguages, ["de", "fr"]);
+  });
+
+  test("transforms language abbrevation to gwr API language code", function (assert) {
+    const service = this.owner.lookup("service:languages");
+
+    assert.strictEqual(service.languageToCode("de"), 9901);
+    assert.strictEqual(service.languageToCode("rm"), 9902);
+    assert.strictEqual(service.languageToCode("fr"), 9903);
+    assert.strictEqual(service.languageToCode("it"), 9904);
+  });
+
+  test("transforms gwr API language code to language abbrevation", function (assert) {
+    const service = this.owner.lookup("service:languages");
+
+    assert.strictEqual(service.codeToLanguage(9901), "de");
+    assert.strictEqual(service.codeToLanguage(9902), "rm");
+    assert.strictEqual(service.codeToLanguage(9903), "fr");
+    assert.strictEqual(service.codeToLanguage(9904), "it");
+  });
+});


### PR DESCRIPTION
Needs #741 
Second part of https://github.com/inosca/ember-ebau-gwr/issues/738

**Multilingual street search**

- [x] Make a first request using the language selected in eBau
- [x] ~~If no streets are found, try the other available languages~~
- [x] Display the street results using the language(s) where results were found (concatenating if results for multiple languages are found)
- [x] Continue further search requests with the same language (for example when continuing typing)

Update after short discussion with @czosel:
We want to stay very defensive with caching and fire one or two requests more rather then getting trapped in some request cache shenanigans. Opting for only canton relevant languages will most effectively cut down request count.